### PR TITLE
build: Replace python security scan and upgrade gitpython

### DIFF
--- a/.github/workflows/reusable-pre-commit.yaml
+++ b/.github/workflows/reusable-pre-commit.yaml
@@ -34,10 +34,9 @@ jobs:
         # install package
         make local-install
 
-    - shell: bash
-      run: |
-        # Pyscan vulnerabilities on python dependencies
-        [[ ! -f "requirements.txt" && ! -f "pyproject.toml" ]] || pyscan -d .
+    - name: Pysentry to scan for transitive vulnerabilities on required dependencies
+      shell: bash
+      run: pysentry-rs --fail-on high --exclude-extra --no-fail-on-unknown --forbid-quarantined
 
     - shell: bash
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 dependencies = [
   "click==8.4.2",
-  "gitpython==3.1.51",
+  "gitpython==3.1.57",
   "pygithub==2.9.1",
   "pyyaml==6.0.3",
   "ulid-py==1.1",
@@ -35,7 +35,7 @@ optional-dependencies.test = [
   "coverage",
   "flake8",
   "isort",
-  "pyscan-rs",
+  "pysentry-rs",
   "pytest",
   "twine",
 ]


### PR DESCRIPTION
<!-- NOTE: Terraform-managed template -->
<!-- Describe the issue -->
#### Issue Summary
_pysentry is more user-friendly and well-maintained than pyscan-rs _


<!-- What is the goal of the Pull Request? -->
#### Why is this PR created?
_This PR accomplishes the following...._
- Replace Python security scan from pyscan to pysentry
- Upgrade gitpython from vulnerable 3.1.51 to 3.1.57
