### PR TITLE
build: switch to use token from default ci to github app

### DIFF
--- a/.github/workflows/cron-tasks.yaml
+++ b/.github/workflows/cron-tasks.yaml
@@ -160,10 +160,17 @@ jobs:
       pull-requests: write
 
     steps:
+      - name: Generate a token from Github App # https://github.com/marketplace/actions/create-github-app-token
+        id: generate-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.SECRET_GITHUB_APP_CLIENT_ID }}
+          private-key: ${{ secrets.SECRET_GITHUB_APP_PEM_FILE }}
+
       - name: Run update-pre-commit # https://github.com/tagdots/update-pre-commit-action
         id: update-pre-commit
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         uses: tagdots/update-pre-commit-action@a80688d12cf761973e340674bcf552af366afba5 # 1.0.28
         with:
           file: .pre-commit-config.yaml

--- a/src/pkg_95120/cli.py
+++ b/src/pkg_95120/cli.py
@@ -353,7 +353,7 @@ def main(file, dry_run, open_pr):
     When --open-pr is used, creates a new branch, commits the changes, pushes
     to remote, and opens a pull request on GitHub.
     """
-    print(f"Starting update-pre-commit (file: {file}, dry-run: {dry_run}, open-pr: {open_pr})...\n")
+    print(f"🚀 Starting update-pre-commit (file: {file}, dry-run: {dry_run}, open-pr: {open_pr})...\n")
     try:
         origin_owner_repo = get_origin_owner_repo()
         original_active_branch_name = get_active_branch_name()


### PR DESCRIPTION
<!-- NOTE: Terraform-managed template -->

#### Issue Summary

_The default GitHub Token could not trigger the CI workflow_

#### Why is this PR created?

_This PR accomplishes the following...._
- Switch from using the default GitHub Token to a token generated by a GitHub App.  This should allow running the CI workflow
